### PR TITLE
Adjust orbit plot layout margins

### DIFF
--- a/yes.py
+++ b/yes.py
@@ -5081,7 +5081,7 @@ class MainApp:
                 overlay_original = True
                 balance_note = "Órbita auto-equilibrada (señales muy correlacionadas)"
             face = "#0f141b" if dark_mode else "white"
-            fig, ax = plt.subplots(figsize=(6, 6))
+            fig, ax = plt.subplots(figsize=(6, 6), constrained_layout=False)
             fig.patch.set_facecolor(face)
             ax.set_facecolor(face)
             accent = self._accent_ui()
@@ -5205,7 +5205,9 @@ class MainApp:
             handles, labels = ax.get_legend_handles_labels()
             if handles:
                 ax.legend(loc="upper right", fontsize=8)
-            fig.tight_layout()
+            # Ajustes manuales de los márgenes para evitar que tight_layout colapse el eje
+            # cuando hay elementos adicionales como la barra de color o la leyenda.
+            fig.subplots_adjust(left=0.12, right=0.88, top=0.92, bottom=0.12)
             return fig
         except Exception:
             return None


### PR DESCRIPTION
## Summary
- prevent orbit analysis figure from using tight_layout, which collapsed the axes when a colorbar was present
- add manual subplot margin adjustments so the colorbar and legend render without squeezing the plot area

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc03cd04e88330837b6ff73d2af26a