### PR TITLE
Organize analysis configuration into tabs

### DIFF
--- a/yes.py
+++ b/yes.py
@@ -4255,7 +4255,7 @@ class MainApp:
                 ], spacing=10, wrap=True),
                 ft.Row([ft.ElevatedButton("Calcular frecuencias", icon=ft.Icons.FUNCTIONS, on_click=self._compute_bearing_freqs_click)], alignment="start")
             ], spacing=8),
-            visible=False,
+            visible=(self.analysis_mode == "assist"),
         )
 
 
@@ -4491,109 +4491,120 @@ class MainApp:
 
         self.config_expanded = True
 
-        self.config_container = ft.Container(
-
-            content=ft.Column([
-
-                # Fila tiempo y FFT
-
+        general_settings = ft.Column(
+            [
+                ft.Text("Columnas base", size=14, weight="bold"),
                 ft.Row([self.time_dropdown, self.fft_dropdown], spacing=10),
-
-                # Unidad para la señal en tiempo
+                ft.Text("Unidades y colores", size=14, weight="bold"),
                 ft.Row([self.time_unit_dd], spacing=10),
-                ft.Text('Colores de graficas:', size=14),
-
                 ft.Row([self.time_color_dd, self.fft_color_dd], spacing=10),
+            ],
+            spacing=12,
+            tight=True,
+        )
 
-
-
-
-                # Señales
-
-                ft.Text("📊 Señales en tiempo:", size=14),
-
+        signal_settings = ft.Column(
+            [
+                ft.Text("📊 Señales en tiempo", size=14, weight="bold"),
                 ft.Row(self.signal_checkboxes, wrap=True, spacing=10),
                 self.combine_signals_cb,
-
-
-
-
-                # Auxiliares
-
-                ft.Text("📌 Variables auxiliares:", size=14),
-
+                ft.Text("📌 Variables auxiliares", size=14, weight="bold"),
                 ft.Column([
-
                     ft.Row([cb, color_dd, style_dd], spacing=10)
-
                     for cb, color_dd, style_dd in self.aux_controls
+                ], spacing=6),
+            ],
+            spacing=12,
+            tight=True,
+        )
 
-                ], spacing=5),
-
-
-
-                # Periodo
-
-                ft.Text("⏱️ Periodo de análisis:", size=14),
-
+        spectrum_settings = ft.Column(
+            [
+                ft.Text("⏱️ Periodo de análisis", size=14, weight="bold"),
                 ft.Row([self.start_time_field, self.end_time_field], spacing=10),
-
-                # Opciones de espectro (visual)
-                ft.Text("Opciones de espectro (visual):", size=14),
+                ft.Text("Opciones de espectro", size=14, weight="bold"),
                 ft.Row([self.hide_lf_cb, self.lf_cutoff_field, self.hf_limit_field, self.runup_3d_cb], spacing=10, wrap=True),
                 ft.Row([self.orbit_cb, self.orbit_x_dd, self.orbit_y_dd], spacing=10, wrap=True),
                 ft.Column([self.fft_zoom_text, self.fft_zoom_slider], spacing=4),
-                ft.Row([self.db_scale_cb, self.sens_unit_dd, self.sensor_sens_field, self.gain_field], spacing=10),
-                ft.Row([self.db_ref_field, self.db_ymin_field, self.db_ymax_field], spacing=10),
+                ft.Text("Escala y calibración", size=14, weight="bold"),
+                ft.Row([self.db_scale_cb, self.sens_unit_dd, self.sensor_sens_field, self.gain_field], spacing=10, wrap=True),
+                ft.Row([self.db_ref_field, self.db_ymin_field, self.db_ymax_field], spacing=10, wrap=True),
+            ],
+            spacing=12,
+            tight=True,
+        )
 
-                # Parámetros de máquina (opcionales)
-                ft.Text("Parámetros de máquina (opcionales):", size=14),
-                ft.Row([self.analysis_mode_dd, self.rpm_hint_field, self.line_freq_dd, self.gear_teeth_field, ft.OutlinedButton("Rodamientos", icon=ft.Icons.LIST_ALT_ROUNDED, on_click=self._goto_bearings_view)], spacing=10, wrap=True),
+        diagnosis_settings = ft.Column(
+            [
+                ft.Text("Parámetros de máquina", size=14, weight="bold"),
+                ft.Row([
+                    self.analysis_mode_dd,
+                    self.rpm_hint_field,
+                    self.line_freq_dd,
+                    self.gear_teeth_field,
+                    ft.OutlinedButton("Rodamientos", icon=ft.Icons.LIST_ALT_ROUNDED, on_click=self._goto_bearings_view),
+                ], spacing=10, wrap=True),
                 self.assisted_box,
                 ft.Row([self.bpfo_field, self.bpfi_field, self.bsf_field, self.ftf_field], spacing=10, wrap=True),
+            ],
+            spacing=12,
+            tight=True,
+        )
 
+        config_tabs = ft.Tabs(
+            animation_duration=250,
+            expand=True,
+            tabs=[
+                ft.Tab(
+                    text="Entradas",
+                    icon=ft.Icons.TUNE_ROUNDED,
+                    content=ft.Container(content=general_settings, padding=10),
+                ),
+                ft.Tab(
+                    text="Señales",
+                    icon=ft.Icons.SHOW_CHART_ROUNDED,
+                    content=ft.Container(content=signal_settings, padding=10),
+                ),
+                ft.Tab(
+                    text="Espectro",
+                    icon=ft.Icons.GRAPHIC_EQ_ROUNDED,
+                    content=ft.Container(content=spectrum_settings, padding=10),
+                ),
+                ft.Tab(
+                    text="Diagnóstico",
+                    icon=ft.Icons.MEDICAL_SERVICES_ROUNDED,
+                    content=ft.Container(content=diagnosis_settings, padding=10),
+                ),
+            ],
+        )
 
+        action_buttons = ft.Row(
+            alignment="center",
+            spacing=20,
+            controls=[
+                ft.ElevatedButton(
+                    "Generar",
+                    icon=ft.Icons.ANALYTICS_ROUNDED,
+                    on_click=self._update_analysis,
+                    style=ft.ButtonStyle(bgcolor=self._accent_ui(), color="white"),
+                ),
+                ft.OutlinedButton(
+                    "Exportar",
+                    icon=ft.Icons.DOWNLOAD_ROUNDED,
+                    on_click=self.exportar_pdf,
+                ),
+            ],
+        )
 
-                # Botones
-
-                ft.Row(
-
-                    alignment="center",
-
-                    spacing=20,
-
-                    controls=[
-
-                        ft.ElevatedButton(
-
-                            "Generar",
-
-                            icon=ft.Icons.ANALYTICS_ROUNDED,
-
-                            on_click=self._update_analysis,
-
-                            style=ft.ButtonStyle(bgcolor=self._accent_ui(), color="white")
-
-                        ),
-
-                        ft.OutlinedButton(
-
-                            "Exportar",
-
-                            icon=ft.Icons.DOWNLOAD_ROUNDED,
-
-                            on_click=self.exportar_pdf
-
-                        )
-
-                    ]
-
-                )
-
-            ], spacing=15),
-
-            visible=self.config_expanded
-
+        self.config_container = ft.Container(
+            content=ft.Column(
+                [
+                    config_tabs,
+                    action_buttons,
+                ],
+                spacing=16,
+            ),
+            visible=self.config_expanded,
         )
 
 


### PR DESCRIPTION
## Summary
- group the analysis configuration controls into dedicated tabs for inputs, signals, spectrum options, and diagnostics
- keep the generate/export actions visible below the tabs and ensure assisted bearing inputs only display in assisted mode

## Testing
- python -m compileall yes.py

------
https://chatgpt.com/codex/tasks/task_e_68dc2322531c8330bbb3a4273d5151e1