### PR TITLE
Normalize motor CSV timestamps for analysis

### DIFF
--- a/VAnálizador.py
+++ b/VAnálizador.py
@@ -7667,7 +7667,21 @@ class MainApp:
                 time_col_name = f"time_seconds_{counter}"
             work_df.insert(0, time_col_name, t_seconds)
 
-            work_df[ts_col] = t_raw
+            # Conservar la columna original para referencia y convertir la principal a segundos
+            raw_units_suffix = {
+                "μs": "microsegundos",
+                "ms": "milisegundos",
+                "s": "segundos_original",
+            }.get(units, "original")
+
+            raw_col_name = f"{ts_col}_{raw_units_suffix}"
+            raw_counter = 1
+            while raw_col_name in work_df.columns:
+                raw_counter += 1
+                raw_col_name = f"{ts_col}_{raw_units_suffix}_{raw_counter}"
+            work_df.insert(1, raw_col_name, t_raw)
+
+            work_df[ts_col] = t_seconds
             work_df[x_col] = acc_x
             work_df[y_col] = acc_y
             work_df[z_col] = acc_z
@@ -7686,8 +7700,13 @@ class MainApp:
                 else ""
             )
             message = (
-                f"Datos de motor detectados ({units}). Se agregó la columna '{time_col_name}' en segundos"
-                f" y las aceleraciones se escalaron a m/s²." + freq_msg
+                f"Datos de motor detectados (tiempos en {units}). Se agregó la columna '{time_col_name}' en segundos,"
+                f" la columna '{ts_col}' se convirtió a segundos y se guardó la serie original en '{raw_col_name}'."
+                " Aceleraciones convertidas a m/s²." + freq_msg
+            ) if units != "s" else (
+                f"Datos de motor detectados. Se agregó la columna '{time_col_name}' en segundos"
+                f" y se normalizó el inicio del tiempo; la columna original '{ts_col}' se conservó en '{raw_col_name}'."
+                " Aceleraciones convertidas a m/s²." + freq_msg
             )
 
             return work_df, message

--- a/VAnálizador.py
+++ b/VAnálizador.py
@@ -38,6 +38,9 @@ import shutil
 
 APP_VERSION = "v1.0.0"
 
+# Escala de conversión de cuentas del acelerómetro a m/s² (rango ±16 g, 16 bits)
+MOTOR_ACC_SCALE = 9.81 * 16 / 32768
+
 # Conjunto de fallas consideradas en la Tabla de Charlotte para motores eléctricos.
 # Cada entrada incluye un identificador, el nombre de la falla y una descripción breve
 # para contextualizar al usuario durante la interpretación del diagnóstico automático.
@@ -7627,6 +7630,11 @@ class MainApp:
             acc_y = y_series.loc[valid_mask].to_numpy(dtype=float)
             acc_z = z_series.loc[valid_mask].to_numpy(dtype=float)
 
+            # Convertir las lecturas crudas del acelerómetro a m/s² usando el factor del sensor
+            acc_x *= MOTOR_ACC_SCALE
+            acc_y *= MOTOR_ACC_SCALE
+            acc_z *= MOTOR_ACC_SCALE
+
             if t_raw.size < 2:
                 return work_df, message
 
@@ -7678,7 +7686,8 @@ class MainApp:
                 else ""
             )
             message = (
-                f"Datos de motor detectados ({units}). Se agregó la columna '{time_col_name}' en segundos." + freq_msg
+                f"Datos de motor detectados ({units}). Se agregó la columna '{time_col_name}' en segundos"
+                f" y las aceleraciones se escalaron a m/s²." + freq_msg
             )
 
             return work_df, message


### PR DESCRIPTION
## Summary
- detect motor CSV files with Timestamp/AccX/AccY/AccZ columns and normalize time to seconds while estimating sampling rate
- prefer the normalized time column and axis aliases as defaults for analysis views
- reset cached sampling rate metadata when files are removed

## Testing
- python -m compileall VAnálizador.py

------
https://chatgpt.com/codex/tasks/task_e_68e3ecae912c8330b93d9ecd3dfed5a0